### PR TITLE
(fix) Typo in README.MD

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -8,7 +8,7 @@ There were compatibility issues reported, so this project has now switched to
 source distribution. In case it does not work for your 
 setup, please raise a ticket.
 
-Tested with Angular2 (2.4.0) and Angular4 (4.0.0) projects created with Angula CLI.
+Tested with Angular2 (2.4.0) and Angular4 (4.0.0) projects created with Angular CLI.
 
 ## Changelog
 


### PR DESCRIPTION
"Angula" > "Angular"