### PR TITLE
Fix connection error when no headers provided

### DIFF
--- a/src/stomp.service.ts
+++ b/src/stomp.service.ts
@@ -111,6 +111,9 @@ export class StompService {
    * Perform connection to STOMP broker
    */
   protected try_connect(): void {
+    if (!this.config.headers) {
+      this.config.headers = {};
+    }
 
     // Attempt connection, passing in a callback
     this.client.connect(


### PR DESCRIPTION
If you connect without headers in your StompConfig, you'll get an error in your console.

![screenshot from 2017-11-02 08-56-28](https://user-images.githubusercontent.com/7972792/32316013-ba279d24-bfae-11e7-8bbc-268a5b002105.png)
