### PR TITLE
Added error subject, fixed codestyle and fixed typo

### DIFF
--- a/src/specs/app/app.module.ts
+++ b/src/specs/app/app.module.ts
@@ -1,5 +1,5 @@
-import {BrowserModule} from '@angular/platform-browser';
-import {NgModule} from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { NgModule } from '@angular/core';
 
 @NgModule({
   declarations: [

--- a/src/specs/app/services/stomp.service.factory.ts
+++ b/src/specs/app/services/stomp.service.factory.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:no-unused-variable */
 
-import {StompService, StompConfig} from '../../../..';
-import {Observable} from 'rxjs/Observable';
+import { StompService, StompConfig } from '../../../..';
+import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
 import * as SockJS from 'sockjs-client';
 

--- a/src/specs/app/services/stomp.service.spec.ts
+++ b/src/specs/app/services/stomp.service.spec.ts
@@ -1,11 +1,11 @@
 /* tslint:disable:no-unused-variable */
 
-import {TestBed, async, inject} from '@angular/core/testing';
-import {StompService, StompState, StompConfig} from '../../../..';
-import {Observable} from 'rxjs/Observable';
+import { TestBed, async, inject } from '@angular/core/testing';
+import { StompService, StompState, StompConfig } from '../../../..';
+import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
-import {defaultConfig, MyStompService, stompServiceFactory} from './stomp.service.factory';
-import {Message} from '@stomp/stompjs';
+import { defaultConfig, MyStompService, stompServiceFactory } from './stomp.service.factory';
+import { Message } from '@stomp/stompjs';
 
 describe('StompService', () => {
   let stompService: StompService;

--- a/src/stomp.config.ts
+++ b/src/stomp.config.ts
@@ -1,5 +1,5 @@
-import {StompHeaders} from './stomp-headers';
-import {Injectable} from '@angular/core';
+import { StompHeaders } from './stomp-headers';
+import { Injectable } from '@angular/core';
 /**
  * Represents a configuration object for the
  * STOMPService to connect to.

--- a/src/stomp.service.ts
+++ b/src/stomp.service.ts
@@ -55,7 +55,7 @@ export class StompService {
   public errorSubject: Subject<string | Stomp.Message>;
 
   /**
-   * Internal array to hold locallly queued messages when STOMP broker is not connected.
+   * Internal array to hold locally queued messages when STOMP broker is not connected.
    */
   protected queuedMessages: {queueName: string, message: string, headers: StompHeaders}[]= [];
 

--- a/src/stomp.service.ts
+++ b/src/stomp.service.ts
@@ -1,13 +1,13 @@
 import { Injectable } from '@angular/core';
 
-import {Observable, Observer, Subscription} from 'rxjs/Rx';
+import { Observable, Observer, Subscription } from 'rxjs/Rx';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 import { StompConfig } from './stomp.config';
 
 import * as Stomp from '@stomp/stompjs';
 import { StompSubscription } from '@stomp/stompjs';
-import {StompHeaders} from './stomp-headers';
+import { StompHeaders } from './stomp-headers';
 
 /**
  * Possible states for the STOMP service


### PR DESCRIPTION
I added an error subject so it is possible to handle errors from the stomp broker.

I needed to catch an error when the `Authorization` header is invalid(#35).