### PR TITLE
Add an option to specify protocols

### DIFF
--- a/src/specs/app/services/stomp.service.factory.ts
+++ b/src/specs/app/services/stomp.service.factory.ts
@@ -16,6 +16,9 @@ export function defaultConfig(): StompConfig {
 
     // Comment above and uncomment below to test with SockJS
     // url: socketProvider,
+    
+    // default protocols
+    protocols: null,
 
     // Headers
     // Typical keys: login, passcode, host

--- a/src/stomp-r.service.ts
+++ b/src/stomp-r.service.ts
@@ -124,7 +124,7 @@ export class StompRService {
 
     // url takes precedence over socketFn
     if (typeof(this._config.url) === 'string') {
-      this.client = Stomp.client(this._config.url);
+      this.client = Stomp.client(this._config.url, this._config.protocols);
     } else {
       this.client = Stomp.over(this._config.url);
     }

--- a/src/stomp.config.ts
+++ b/src/stomp.config.ts
@@ -22,6 +22,13 @@ export class StompConfig {
    * }
    */
   url: string | (() => any);
+  
+  /**
+   * Stopm protocols that will be used
+   * They are being set in the Sec-WebSocket-Protocol header
+   * Leave empty for default protocols
+   */  
+  protocols: string[];
 
   /**
    * Headers

--- a/src/stomp.config.ts
+++ b/src/stomp.config.ts
@@ -24,7 +24,7 @@ export class StompConfig {
   url: string | (() => any);
   
   /**
-   * Stopm protocols that will be used
+   * Stomp protocols that will be used
    * They are being set in the Sec-WebSocket-Protocol header
    * Leave empty for default protocols
    */  


### PR DESCRIPTION
I've simply extended the config object and added an (already existing in real Stomp Client) second parameter of protocols. If the parameter is left as 'undefined', default protocols will be taken. 